### PR TITLE
Update STACClient

### DIFF
--- a/paint/data/stac_client.py
+++ b/paint/data/stac_client.py
@@ -1206,9 +1206,16 @@ class StacClient:
             if heliostats is None:
                 root = self.get_catalog(href=mappings.CATALOGUE_URL)
                 log.info("Loading all children in root catalog - please be patient!")
-                all_children = list(
-                    root.get_children()
-                )  # Convert generator to list to save time later.
+                all_children = list(root.get_children())
+                for i in range(
+                    len(all_children) - 1, -1, -1
+                ):  # Iterate backwards through the list.
+                    child = all_children[i]
+                    if (
+                        child.id == mappings.WEATHER_COLLECTION_ID
+                        or child.id == mappings.TOWER_FILE_NAME
+                    ):
+                        all_children.pop(i)
             else:
                 # Find the catalogs for each desired heliostat.
                 log.info("Loading catalogs for desired heliostats.")


### PR DESCRIPTION
# Description

There was a bug in the function to download the metadata that was accidentally included with the addition of checkpointing. If no checkpoints or list of heliostats is provided, metadata for all children in the main catalog was downloaded, which included the weather and tower child. These have now been removed meaning the metadata download works as desired.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
